### PR TITLE
Adjust contact form to accomodate new recruitment flow 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ npm-debug.log*
 
 # eslint
 .eslintcache
+
+# Playwright
+/playwright/.auth/

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       "devDependencies": {
         "@eslint/js": "^9.20.0",
         "@iconify-json/ic": "^1.1.17",
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "^1.59.1",
         "@tanstack/eslint-plugin-query": "^5.66.1",
         "@types/node": "^22.10.5",
         "@typescript-eslint/parser": "^8.24.1",
@@ -1908,13 +1908,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.56.1"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7192,13 +7192,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.56.1"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7211,9 +7211,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "playwright test"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@iconify-json/ic": "^1.1.17",
-    "@playwright/test": "^1.49.1",
+    "@playwright/test": "^1.59.1",
     "@tanstack/eslint-plugin-query": "^5.66.1",
     "@types/node": "^22.10.5",
     "@typescript-eslint/parser": "^8.24.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://localhost:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -28,18 +28,19 @@ export default function ContactForm() {
         setState(State.Sent);
         return;
       }
+      const messageParts: string[] = [];
+      if (formJson.years_of_experience) messageParts.push(`Years of experience: ${formJson.years_of_experience}`);
+      if (formJson.home_team) messageParts.push(`Home team: ${formJson.home_team}`);
+      if (formJson.commitment) messageParts.push(`Commitment: ${formJson.commitment}`);
+      messageParts.push(`Message: ${formJson.message}`);
+
       await emailjs.send(
         "default_service",
         "template_aillhuc",
         {
           from_name: formJson.name,
           from_email: formJson.email,
-          message: [
-            `Years of experience: ${formJson.years_of_experience}`,
-            `Home team: ${formJson.home_team}`,
-            `Commitment: ${formJson.commitment}`,
-            `Message: ${formJson.message}`,
-          ].join("\n"),
+          message: messageParts.join("\n"),
         },
         { publicKey: "YGL6jQ4ZZE8y_Ihth" },
       );
@@ -149,6 +150,7 @@ export default function ContactForm() {
             </label>
             <textarea
               name="message"
+              required
               className="h-32 w-full rounded-md border border-gray-300 px-4 py-2"
             ></textarea>
           </div>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -118,7 +118,6 @@ export default function ContactForm() {
             <input
               type="text"
               name="home_team"
-              required
               className="w-full rounded-md border border-gray-300 px-4 py-2"
             />
           </div>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -106,7 +106,6 @@ export default function ContactForm() {
               type="number"
               name="years_of_experience"
               min="0"
-              required
               className="w-full rounded-md border border-gray-300 px-4 py-2"
             />
           </div>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -34,7 +34,12 @@ export default function ContactForm() {
         {
           from_name: formJson.name,
           from_email: formJson.email,
-          message: formJson.message,
+          message: [
+            `Years of experience: ${formJson.years_of_experience}`,
+            `Home team: ${formJson.home_team}`,
+            `Commitment: ${formJson.commitment}`,
+            `Message: ${formJson.message}`,
+          ].join("\n"),
         },
         { publicKey: "YGL6jQ4ZZE8y_Ihth" },
       );
@@ -91,12 +96,62 @@ export default function ContactForm() {
           </div>
 
           <div className="mb-4">
+            <label
+              htmlFor="years_of_experience"
+              className="mb-2 block text-sm font-bold"
+            >
+              Years of experience:
+            </label>
+            <input
+              type="number"
+              name="years_of_experience"
+              min="0"
+              required
+              className="w-full rounded-md border border-gray-300 px-4 py-2"
+            />
+          </div>
+
+          <div className="mb-4">
+            <label htmlFor="home_team" className="mb-2 block text-sm font-bold">
+              Home team:
+            </label>
+            <input
+              type="text"
+              name="home_team"
+              required
+              className="w-full rounded-md border border-gray-300 px-4 py-2"
+            />
+          </div>
+
+          <div className="mb-4">
+            <p className="mb-2 text-sm font-bold">
+              How long are you planning to play with us?
+            </p>
+            <label className="mb-2 flex items-center gap-2">
+              <input
+                type="radio"
+                name="commitment"
+                value="Join the team (long term)"
+                required
+              />
+              Join the team (long term)
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="commitment"
+                value="Join one/few training/s"
+              />
+              Join one/few training/s
+            </label>
+          </div>
+
+          <div className="mb-4">
             <label htmlFor="message" className="mb-2 block text-sm font-bold">
               Message:
             </label>
             <textarea
               name="message"
-              required
               className="h-32 w-full rounded-md border border-gray-300 px-4 py-2"
             ></textarea>
           </div>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -130,7 +130,6 @@ export default function ContactForm() {
                 type="radio"
                 name="commitment"
                 value="Join the team (long term)"
-                required
               />
               Join the team (long term)
             </label>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -29,9 +29,14 @@ export default function ContactForm() {
         return;
       }
       const messageParts: string[] = [];
-      if (formJson.years_of_experience) messageParts.push(`Years of experience: ${formJson.years_of_experience}`);
-      if (formJson.home_team) messageParts.push(`Home team: ${formJson.home_team}`);
-      if (formJson.commitment) messageParts.push(`Commitment: ${formJson.commitment}`);
+      if (formJson.years_of_experience)
+        messageParts.push(
+          `Years of experience: ${formJson.years_of_experience}`,
+        );
+      if (formJson.home_team)
+        messageParts.push(`Home team: ${formJson.home_team}`);
+      if (formJson.commitment)
+        messageParts.push(`Commitment: ${formJson.commitment}`);
       messageParts.push(`Message: ${formJson.message}`);
 
       await emailjs.send(

--- a/tests/ContactForm.spec.js
+++ b/tests/ContactForm.spec.js
@@ -16,9 +16,6 @@ test('contact form sends correct data to emailjs', async ({ page }) => {
   await page.getByRole('button', { name: 'Contact' }).click();
   await page.locator('input[name="name"]').fill('testName');
   await page.locator('input[name="email"]').fill('testemail@test.com');
-  await page.getByRole('spinbutton').fill('123');
-  await page.locator('input[name="home_team"]').fill('CBEStars');
-  await page.getByRole('radio', { name: 'Join one/few training/s' }).click();
   await page.locator('textarea[name="message"]').fill('stmessage');
   await page.getByRole('button', { name: 'Submit' }).click();
 
@@ -30,11 +27,45 @@ test('contact form sends correct data to emailjs', async ({ page }) => {
   expect(capturedBody.template_params).toEqual({
     from_name: 'testName',
     from_email: 'testemail@test.com',
+    message: 'Message: stmessage',
+  });
+});
+
+test('contact form sends correct data when user fills optional fields to join the team', async ({ page }) => {
+  let capturedBody = null;
+
+  await page.route('**/api.emailjs.com/**', async (route) => {
+    capturedBody = route.request().postDataJSON();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 200, text: 'OK' }),
+    });
+  });
+
+  await page.goto('http://localhost:4321/');
+  await page.getByRole('button', { name: 'Contact' }).click();
+  await page.locator('input[name="name"]').fill('testName');
+  await page.locator('input[name="email"]').fill('testemail@test.com');
+  await page.getByRole('spinbutton').fill('3');
+  await page.locator('input[name="home_team"]').fill('CBEStars');
+  await page.getByRole('radio', { name: 'Join one/few training/s' }).click();
+  await page.locator('textarea[name="message"]').fill('Looking to join a training session');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByText('Thanks for contacting us!')).toBeVisible();
+
+  expect(capturedBody).not.toBeNull();
+  expect(capturedBody.service_id).toBe('default_service');
+  expect(capturedBody.template_id).toBe('template_aillhuc');
+  expect(capturedBody.template_params).toEqual({
+    from_name: 'testName',
+    from_email: 'testemail@test.com',
     message: [
-      'Years of experience: 123',
+      'Years of experience: 3',
       'Home team: CBEStars',
       'Commitment: Join one/few training/s',
-      'Message: stmessage',
+      'Message: Looking to join a training session',
     ].join('\n'),
   });
 });
@@ -51,9 +82,7 @@ test('contact form with company field blocks emailjs call', async ({ page }) => 
   await page.getByRole('button', { name: 'Contact' }).click();
   await page.locator('input[name="name"]').fill('bot');
   await page.locator('input[name="email"]').fill('bot@spam.com');
-  await page.getByRole('spinbutton').fill('0');
-  await page.locator('input[name="home_team"]').fill('Bots FC');
-  await page.getByRole('radio', { name: 'Join one/few training/s' }).click();
+  await page.locator('textarea[name="message"]').fill('bot message');
   await page.evaluate(() => {
     document.querySelector('input[name="company"]').value = 'ACME Corp';
   });

--- a/tests/ContactForm.spec.js
+++ b/tests/ContactForm.spec.js
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+test('contact form sends correct data to emailjs', async ({ page }) => {
+  let capturedBody = null;
+
+  await page.route('**/api.emailjs.com/**', async (route) => {
+    capturedBody = route.request().postDataJSON();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 200, text: 'OK' }),
+    });
+  });
+
+  await page.goto('http://localhost:4321/');
+  await page.getByRole('button', { name: 'Contact' }).click();
+  await page.locator('input[name="name"]').fill('testName');
+  await page.locator('input[name="email"]').fill('testemail@test.com');
+  await page.getByRole('spinbutton').fill('123');
+  await page.locator('input[name="home_team"]').fill('CBEStars');
+  await page.getByRole('radio', { name: 'Join one/few training/s' }).click();
+  await page.locator('textarea[name="message"]').fill('stmessage');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByText('Thanks for contacting us!')).toBeVisible();
+
+  expect(capturedBody).not.toBeNull();
+  expect(capturedBody.service_id).toBe('default_service');
+  expect(capturedBody.template_id).toBe('template_aillhuc');
+  expect(capturedBody.template_params).toEqual({
+    from_name: 'testName',
+    from_email: 'testemail@test.com',
+    message: [
+      'Years of experience: 123',
+      'Home team: CBEStars',
+      'Commitment: Join one/few training/s',
+      'Message: stmessage',
+    ].join('\n'),
+  });
+});
+
+test('contact form with company field blocks emailjs call', async ({ page }) => {
+  let emailjsCalled = false;
+
+  await page.route('**/api.emailjs.com/**', async (route) => {
+    emailjsCalled = true;
+    await route.continue();
+  });
+
+  await page.goto('http://localhost:4321/');
+  await page.getByRole('button', { name: 'Contact' }).click();
+  await page.locator('input[name="name"]').fill('bot');
+  await page.locator('input[name="email"]').fill('bot@spam.com');
+  await page.getByRole('spinbutton').fill('0');
+  await page.locator('input[name="home_team"]').fill('Bots FC');
+  await page.getByRole('radio', { name: 'Join one/few training/s' }).click();
+  await page.evaluate(() => {
+    document.querySelector('input[name="company"]').value = 'ACME Corp';
+  });
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByText('Thanks for contacting us!')).toBeVisible();
+  expect(emailjsCalled).toBe(false);
+});


### PR DESCRIPTION
- Add playright(for end-to-end specs) config
- Add new fields to the contact form

## Why?
A new flow for the recruitment process is being implemented, and as part of this, we want to gather more details to better understand the person who wants to come train with us.

Sidenote: The new flow for the recruitment process will be posted in the team's WhatsApp group for all to see soon.


## Next steps
- I don't have access to the lobstars email id or emailjs to check if this really works, so I need help with testing it production